### PR TITLE
Fix broken virtualbox url for 12.2

### DIFF
--- a/YaST/Repos/_openSUSE_122_Additional.xml
+++ b/YaST/Repos/_openSUSE_122_Additional.xml
@@ -663,7 +663,7 @@
         <description xml:lang="wa">Dene les modêyes a djoû d' VirtualBox, on forvoeyeu libe-sourdant complet a uzaedje djenerå po l' éndjolreye x86.</description>
         <description xml:lang="zh_CN">提供最新编译的 VirtualBox，它是用于一般目的的针对 x86 硬件的开源的完全虚拟器。</description>
         <description xml:lang="zh_TW">提供了最新版本的 VirtualBox，一個一般用途的開放原始碼 x86 硬體完整虛擬機器 </description>
-        <url>http://download.opensuse.org/repositories/Virtualization:/VirtualBox_backports/openSUSE_12.2/</url>
+        <url>http://download.opensuse.org/repositories/Virtualization/openSUSE_12.2/</url>
       </repository>
       <repository recommended="false" format="rpm-md">
         <name>openSUSE BuildService - PHP</name>

--- a/YaST/Repos/_openSUSE_122_Additional.xml.in
+++ b/YaST/Repos/_openSUSE_122_Additional.xml.in
@@ -44,7 +44,7 @@
         <_name>openSUSE BuildService - Virtualization (VirtualBox)</_name>
         <_summary>Latest builds of Virtualbox</_summary>
         <_description>Provides up-to-date builds of VirtualBox, a general-purpose open-source full virtualizer for x86 hardware.</_description>
-        <url>http://download.opensuse.org/repositories/Virtualization:/VirtualBox_backports/openSUSE_12.2/</url>
+        <url>http://download.opensuse.org/repositories/Virtualization/openSUSE_12.2/</url>
       </repository>
       <repository recommended="false" format="rpm-md">
         <_name>openSUSE BuildService - PHP</_name>


### PR DESCRIPTION
The repo url for virtualbox on 12.2 is broken - I've fixed it (I hope, not quite sure what the _openSUSE_122_Additional.xml.in is for).
