### PR TITLE
removing obsolete kde:updatedapps repo

### DIFF
--- a/YaST/Repos/_openSUSE_122_Additional.xml.in
+++ b/YaST/Repos/_openSUSE_122_Additional.xml.in
@@ -59,12 +59,6 @@
         <url>http://download.opensuse.org/repositories/server:/database/openSUSE_12.2/</url>
       </repository>
       <repository recommended="false" format="yast">
-        <_name>openSUSE BuildService - KDE:UpdatedApps</_name>
-        <_summary>Updated versions of KDE applications</_summary>
-        <_description>Updates to the KDE software that is shipped with the distribution (backports).</_description>
-        <url>http://download.opensuse.org/repositories/KDE:/UpdatedApps/openSUSE_12.2/</url>
-      </repository>
-      <repository recommended="false" format="yast">
         <_name>openSUSE BuildService - KDE:Extra</_name>
         <_summary>Community repository for KDE</_summary>
         <_description>Provides additional KDE software maintained by the openSUSE KDE community.</_description>

--- a/YaST/Repos/_openSUSE_123_Additional.xml.in
+++ b/YaST/Repos/_openSUSE_123_Additional.xml.in
@@ -59,12 +59,6 @@
         <url>http://download.opensuse.org/repositories/server:/database/openSUSE_12.3/</url>
       </repository>
       <repository recommended="false" format="yast">
-        <_name>openSUSE BuildService - KDE:UpdatedApps</_name>
-        <_summary>Updated versions of KDE applications</_summary>
-        <_description>Updates to the KDE software that is shipped with the distribution (backports).</_description>
-        <url>http://download.opensuse.org/repositories/KDE:/UpdatedApps/openSUSE_12.3/</url>
-      </repository>
-      <repository recommended="false" format="yast">
         <_name>openSUSE BuildService - KDE:Extra</_name>
         <_summary>Community repository for KDE</_summary>
         <_description>Provides additional KDE software maintained by the openSUSE KDE community.</_description>

--- a/YaST/Repos/_openSUSE_131_Additional.xml.in
+++ b/YaST/Repos/_openSUSE_131_Additional.xml.in
@@ -59,12 +59,6 @@
         <url>http://download.opensuse.org/repositories/server:/database/openSUSE_13.1/</url>
       </repository>
       <repository recommended="false" format="yast">
-        <_name>openSUSE BuildService - KDE:UpdatedApps</_name>
-        <_summary>Updated versions of KDE applications</_summary>
-        <_description>Updates to the KDE software that is shipped with the distribution (backports).</_description>
-        <url>http://download.opensuse.org/repositories/KDE:/UpdatedApps/openSUSE_13.1/</url>
-      </repository>
-      <repository recommended="false" format="yast">
         <_name>openSUSE BuildService - KDE:Extra</_name>
         <_summary>Community repository for KDE</_summary>
         <_description>Provides additional KDE software maintained by the openSUSE KDE community.</_description>


### PR DESCRIPTION
KDE:UpdatedApps is now obsolete and unmaintained - and will be removed from OBS when 12.3 is EOL at the latest. 

The packages which used to be available via KDE:UpdatedApps are now available via KDE:Extra instead.
