### PR TITLE
Community repos: webcam has not been published for anything > 11.4

### DIFF
--- a/YaST/Repos/_openSUSE_132_Additional.xml.in
+++ b/YaST/Repos/_openSUSE_132_Additional.xml.in
@@ -36,12 +36,6 @@
         <url>http://download.opensuse.org/repositories/games/openSUSE_13.2/</url>
       </repository>
       <repository recommended="false" format="rpm-md">
-        <_name>openSUSE BuildService - Drivers for webcams</_name>
-        <_summary>Recent drivers for webcams</_summary>
-        <_description>Contains recent drivers for hundreds of different webcams.</_description>
-        <url>http://download.opensuse.org/repositories/drivers:/webcam/openSUSE_13.2/</url>
-      </repository>
-      <repository recommended="false" format="rpm-md">
         <_name>openSUSE BuildService - Virtualization (VirtualBox)</_name>
         <_summary>Latest builds of Virtualbox</_summary>
         <_description>Provides up-to-date builds of VirtualBox, a general-purpose open-source full virtualizer for x86 hardware.</_description>


### PR DESCRIPTION
Just remembered that on a review I saw, this repo was mentioned as 'not being functional' - which makes sense: the latest that is enabled for building is 11.4
