### PR TITLE
Add Repo definitions for openSUSE Leap 42.1

### DIFF
--- a/YaST/Repos/_openSUSE_Leap_42.1_Additional.xml.in
+++ b/YaST/Repos/_openSUSE_Leap_42.1_Additional.xml.in
@@ -1,0 +1,134 @@
+<?xml version="1.0"?>
+<!-- Additional Repositories for openSUSE Leap 42.1
+     These are maintained by Stephan Kulow <coolo@suse.de> and Dominique Leuenberger <dimstar@suse.de> -->
+<metapackage xmlns:os="http://opensuse.org/Standards/One_Click_Install" xmlns="http://opensuse.org/Standards/One_Click_Install">
+  <group distversion="openSUSE Build Service">
+    <repositories>
+<!-- LXDE repo not yet enabled for Leap 42.1 / dimstar / 20151006
+      <repository recommended="false" format="rpm-md">
+        <_name>openSUSE BuildService - LXDE</_name>
+        <_summary>Latest LXDE release</_summary>
+        <_description>The LXDE repository in the openSUSE Build Service, which provides you with the unsupported but latest version of the LX desktop environment and software.</_description>
+        <url>http://download.opensuse.org/repositories/X11:/lxde/openSUSE_Leap_42.1/</url>
+      </repository>
+LXDE repo not yet enabled for Leap 42.1 / dimstar / 20151006 -->
+<!-- LibreOffice repo not yet enabled for Leap 42.1 / dimstar / 20151006
+      <repository recommended="false" format="rpm-md">
+        <_name>openSUSE BuildService - LibreOffice</_name>
+        <_summary>Latest stable LibreOffice release</_summary>
+        <_description>Provides you with the latest stable version of LibreOffice, the Office suite that openSUSE uses.</_description>
+        < Check the version here each time for what is supposed to be set >
+        <url>http://download.opensuse.org/repositories/LibreOffice:/4.3/openSUSE_Leap_42.1/</url>
+      </repository>
+LibreOffice repo not yet enabled for Leap 42.1 / dimstar / 20151006 -->
+      <repository recommended="false" format="rpm-md">
+        <_name>openSUSE BuildService - Mozilla</_name>
+        <_summary>Most recent builds of Mozilla Software like Firefox</_summary>
+        <_description>Containing the latest releases of all Mozilla software, such as the popular Thunderbird (mail client), Firefox and SeaMonkey (web browsers). </_description>
+        <url>http://download.opensuse.org/repositories/mozilla/openSUSE_Leap_42.1/</url>
+      </repository>
+      <repository recommended="false" format="rpm-md">
+        <_name>openSUSE BuildService - Wine CVS Builds</_name>
+        <_summary>Snapshots of Wine CVS</_summary>
+        <_description>Wine is an Open Source implementation of the Windows API, so it allows you to run some Windows applications in openSUSE. This repository provides the latest CVS (development) snapshot packages of Wine.</_description>
+        <url>http://download.opensuse.org/repositories/Emulators:/Wine/openSUSE_Leap_42.1/</url>
+      </repository>
+<!-- games repo not yet enabled for Leap 42.1 / dimstar / 20151006
+      <repository recommended="false" format="rpm-md">
+        <_name>openSUSE BuildService - Games</_name>
+        <_summary>A collection of action games</_summary>
+        <_description>Contains several action games including Open Arena (shoot 'em up), Flight Gear (flight simulator) and Torcs (3D racing simulator). </_description>
+        <url>http://download.opensuse.org/repositories/games/openSUSE_Leap_42.1/</url>
+      </repository>
+games repo not yet enabled for Leap 42.1 / dimstar / 20151006 -->
+<!-- Virtualization repo not yet enabled for Leap 42.1 / dimstar / 20151006
+      <repository recommended="false" format="rpm-md">
+        <_name>openSUSE BuildService - Virtualization (VirtualBox)</_name>
+        <_summary>Latest builds of Virtualbox</_summary>
+        <_description>Provides up-to-date builds of VirtualBox, a general-purpose open-source full virtualizer for x86 hardware.</_description>
+        <url>http://download.opensuse.org/repositories/Virtualization/openSUSE_Leap_42.1/</url>
+      </repository>
+Virtualization repo not yet enabled for Leap 42.1 / dimstar / 20151006 -->
+<!-- PHP repo not yet enabled for Leap 42.1 / dimstar / 20151006
+      <repository recommended="false" format="rpm-md">
+        <_name>openSUSE BuildService - PHP</_name>
+        <_summary>Latest updates for PHP software</_summary>
+        <_description>Provides the latest packages and multiple-version builds of PHP software.</_description>
+        <url>http://download.opensuse.org/repositories/server:/php/openSUSE_Leap_42.1/</url>
+      </repository>
+PHP repo not yet enabled for Leap 42.1 / dimstar / 20151006 -->
+      <repository recommended="false" format="rpm-md">
+        <_name>openSUSE BuildService - Database</_name>
+        <_summary>Latest updates for database software</_summary>
+        <_description>Latest updates for database software including Firebird and MySQL.</_description>
+        <url>http://download.opensuse.org/repositories/server:/database/openSUSE_Leap_42.1/</url>
+      </repository>
+<!-- KDE Extra repo not yet enabled for Leap 42.1 / dimstar / 20151006
+      <repository recommended="false" format="yast">
+        <_name>openSUSE BuildService - KDE:Extra</_name>
+        <_summary>Community repository for KDE</_summary>
+        <_description>Provides additional KDE software maintained by the openSUSE KDE community.</_description>
+        <url>http://download.opensuse.org/repositories/KDE:/Extra/openSUSE_Leap_42.1/</url>
+      </repository>
+KDE Extra repo not yet enabled for Leap 42.1 / dimstar / 20151006 -->
+      <repository recommended="false" format="yast">
+        <_name>openSUSE BuildService - GNOME:Apps</_name>
+        <_summary>Backports of GNOME applications</_summary>
+        <_description>Updates to the GNOME software that is shipped with the distribution (backports).</_description>
+        <url>http://download.opensuse.org/repositories/GNOME:/Apps/openSUSE_Leap_42.1/</url>
+      </repository>
+<!-- Mono repo not yet enabled for Leap 42.1 / dimstar / 20151006
+      <repository recommended="false" format="yast">
+        <_name>openSUSE BuildService - Mono:Community</_name>
+        <_summary>Community repository for Mono applications</_summary>
+        <_description>Updates and Additions of applications written in Mono.</_description>
+        <url>http://download.opensuse.org/repositories/Mono:/Community/openSUSE_Leap_42.1/</url>
+      </repository>
+Mono repo not yet enabled for Leap 42.1 / dimstar / 20151006 -->
+      <repository recommended="false" format="yast">
+        <_name>openSUSE BuildService - devel:languages:perl</_name>
+        <_summary>Community repository for Perl modules</_summary>
+        <_description>Updates and Additions for Perl modules</_description>
+        <url>http://download.opensuse.org/repositories/devel:/languages:/perl/openSUSE_Leap_42.1/</url>
+      </repository>
+      <repository recommended="false" format="yast">
+        <_name>openSUSE BuildService - devel:languages:python</_name>
+        <_summary>Community repository for Python modules</_summary>
+        <_description>Updates and Additions for Python modules</_description>
+        <url>http://download.opensuse.org/repositories/devel:/languages:/python/openSUSE_Leap_42.1/</url>
+      </repository>
+<!-- filesystem repo not yet enabled for Leap 42.1 / dimstar / 20151006
+      <repository recommended="false" format="rpm-md">
+        <_name>openSUSE BuildService - filesystems</_name>
+        <_summary>Filesystem tools and FUSE-related packages</_summary>
+        <_description>Filesystem tools and FUSE-related packages.</_description>
+        <url>http://download.opensuse.org/repositories/filesystems/openSUSE_Leap_42.1/</url>
+      </repository>
+filesystem repo not yet enabled for Leap 42.1 / dimstar / 20151006 -->
+<!-- Education repo not yet enabled for Leap 42.1 / dimstar / 20151006
+      <repository recommended="false" format="rpm-md">
+        <_name>openSUSE BuildService - Education</_name>
+        <_summary>Applications for education users</_summary>
+        <_description>Contains several packages which might be interesting for educational use</_description>
+        <url>http://download.opensuse.org/repositories/Education/openSUSE_Leap_42.1/</url>
+      </repository>
+Education repo not yet enabled for Leap 42.1 / dimstar / 20151006 -->
+<!-- Java packages repo not yet enabled for Leap 42.1 / dimstar / 20151006
+      <repository recommended="false" format="rpm-md">
+        <_name>openSUSE BuildService - Java:packages</_name>
+        <_summary>Bleeding-edge Java packages</_summary>
+        <_description>Provides uptodate Java packages (Factory backports)</_description>
+        <url>http://download.opensuse.org/repositories/Java:/packages/openSUSE_Leap_42.1/</url>
+      </repository>
+Java packages repo not yet enabled for Leap 42.1 / dimstar / 20151006 -->
+<!-- KDE3 repo not yet enabled for Leap 42.1 / dimstar / 20151006
+      <repository recommended="false" format="rpm-md">
+        <_name>openSUSE BuildService - KDE:KDE3</_name>
+        <_summary>Maintained KDE 3 packages</_summary>
+        <_description>Provides old KDE for newer openSUSE</_description>
+        <url>http://download.opensuse.org/repositories/KDE:/KDE3/openSUSE_Leap_42.1/</url>
+      </repository>
+KDE3 repo not yet enabled for Leap 42.1 / dimstar / 20151006 -->
+    </repositories>
+  </group>
+</metapackage>

--- a/YaST/Repos/_openSUSE_Leap_42.1_Default.xml.in
+++ b/YaST/Repos/_openSUSE_Leap_42.1_Default.xml.in
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<!-- Main Repositories for openSUSE Leap 42.1 
+     These are maintained by Stephan Kulow <coolo@suse.de> and Dominique Leuenberger <dimstar@suse.de> -->
+<metapackage xmlns:os="http://opensuse.org/Standards/One_Click_Install" xmlns="http://opensuse.org/Standards/One_Click_Install">
+    <group distversion="openSUSE Main Repository">
+	<repositories>
+
+	    <repository recommended="true" format="yast">
+		<_name>Main Repository (OSS)</_name>
+		<_summary>Main repository of openSUSE Leap 42.1 including only
+		Open Source Software</_summary>
+		<_description>The big Open Source Software (OSS) repository
+		for openSUSE Leap 42.1, giving you access to thousands of
+		packages maintained by the openSUSE team. (Due to the size of
+		the repository, adding it may take some time. 512 MB of RAM
+		or an enabled SWAP partition are highly recommended in case
+		you want to access this repository at installation time.)
+		 </_description>
+		<url>http://download.opensuse.org/distribution/leap/42.1/repo/oss/</url>
+	    </repository>
+	    <repository recommended="true" format="yast">
+		<_name>Main Repository (NON-OSS)</_name>
+		<_summary>Non-Open Source Software Addon repository for openSUSE Leap 42.1</_summary>
+		<_description>The official openSUSE Leap 42.1 repository for all
+		Non-Open Source Software maintained by the openSUSE team,
+		including Opera, Steam, Flash, and more.</_description>
+		<url>http://download.opensuse.org/distribution/leap/42.1/repo/non-oss/</url>
+	    </repository>
+      <repository recommended="false" format="yast">
+        <_name>Main Repository (Sources)</_name>
+        <_summary>Main repository of openSUSE Leap 42.1 (Source packages)</_summary>
+        <_description>The repository of all source packages in openSUSE Leap 42.1. For experts only.</_description>
+        <url>http://download.opensuse.org/source/distribution/leap/42.1/repo/oss/</url>
+      </repository>
+	    <repository recommended="false" format="yast">
+		<_name>Main Repository (DEBUG)</_name>
+		<_summary>Main repository of openSUSE Leap 42.1 including the debuginfo packages</_summary>
+		<_description>This repository is useful for those that want to debug applications on openSUSE Leap 42.1. For experts only.</_description>
+		<url>http://download.opensuse.org/debug/distribution/leap/42.1/repo/oss/</url>
+	    </repository>
+      <repository recommended="false" format="rpm-md">
+        <_name>Main Update Repository</_name>
+        <_summary>Repository for official updates to openSUSE Leap 42.1</_summary>
+        <_description>In this repository you find security and maintenance updates to openSUSE Leap 42.1.</_description>
+        <url>http://download.opensuse.org/update/leap/42.1/oss</url>
+      </repository>
+      <repository recommended="false" format="rpm-md">
+        <_name>Update Repository (Non-Oss)</_name>
+        <_summary>Repository for official non free updates to openSUSE Leap 42.1</_summary>
+        <_description>In this repository you find security and maintenance updates to openSUSE Leap 42.1.</_description>
+        <url>http://download.opensuse.org/update/leap/42.1/non-oss/</url>
+      </repository>
+            <repository recommended="false" format="yast">
+                <_name>Update Repository (DEBUG)</_name>
+                <_summary>Update repository of openSUSE Leap 42.1 debuginfo packages</_summary>
+                <_description>This repository is useful for those that want to debug applications on openSUSE Leap 42.1. For experts only.</_description>
+                <url>http://download.opensuse.org/debug/update/leap/42.1/</url>
+            </repository>
+	</repositories>
+    </group>
+</metapackage>

--- a/YaST/Repos/openSUSE_Leap_42.1_Servers.xml.in
+++ b/YaST/Repos/openSUSE_Leap_42.1_Servers.xml.in
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<!-- Additional Repositories for openSUSE Leap 42.1
+     These are maintained by Stephan Kulow <coolo@suse.de> and Dominque Leuenberger <dimstar@suse.de> -->
+<productDefines xmlns="http://www.suse.com/1.0/yast2ns" xmlns:config="http://www.suse.com/1.0/configns">
+    <servers config:type="list">
+
+	<!-- official openSUSE links -->
+	<item>
+	    <link>http://download.opensuse.org/YaST/Repos/_openSUSE_Leap_42.1_Default.xml</link>
+	    <!-- to enable it during installation -->
+	    <installation_repo config:type="boolean">true</installation_repo>
+	    <official config:type="boolean">true</official>
+	</item>
+
+	<item>
+	    <link>http://download.opensuse.org/YaST/Repos/_openSUSE_Leap_42.1_Additional.xml</link>
+	    <official config:type="boolean">true</official>
+	</item>
+
+	<!-- Community links -->
+	<!-- Community repos not yet setup / dimstar / 20151006
+	<item>
+	    <link>http://opensuse-community.org/openSUSE_Leap_42.1_Community_Additional.xml</link>
+	    <official config:type="boolean">false</official>
+        </item>
+        Community repos not yet setup / dimstar / 20151006 -->
+
+    </servers>
+</productDefines>


### PR DESCRIPTION
https://progress.opensuse.org/issues/8942

A lot of repos in Additional are not yet enabled.. I'll get in touch with the maintainers to see if they want them added...