### PR TITLE
Correct openSUSE Leap 42.1 Update Debug URL - boo#961364

### DIFF
--- a/YaST/Repos/_openSUSE_Leap_42.1_Default.xml
+++ b/YaST/Repos/_openSUSE_Leap_42.1_Default.xml
@@ -430,7 +430,7 @@
                 <description xml:lang="uk">Це сховище придатне для тих, хто хоче зневаджувати програми на openSUSE Leap 42.1. Тільки для знавців.</description>
                 <description xml:lang="zh_CN">本软件源只对那些想要在 openSUSE Leap 42.1 中调试程序的人有用。仅供专家使用。</description>
                 <description xml:lang="zh_TW">這個套件庫對想要在 openSUSE Leap 42.1 偵錯應用程式非常有用。僅提供專家使用。</description>
-                <url>http://download.opensuse.org/debug/update/leap/42.1/</url>
+                <url>http://download.opensuse.org/debug/update/leap/42.1/oss/</url>
             </repository>
             <repository recommended="false" format="rpm-md">
                 <name>Untested Updates</name>

--- a/YaST/Repos/_openSUSE_Leap_42.1_Default.xml.in
+++ b/YaST/Repos/_openSUSE_Leap_42.1_Default.xml.in
@@ -49,7 +49,7 @@
                 <_name>Update Repository (DEBUG)</_name>
                 <_summary>Update repository of openSUSE Leap 42.1 debuginfo packages</_summary>
                 <_description>This repository is useful for those that want to debug applications on openSUSE Leap 42.1. For experts only.</_description>
-                <url>http://download.opensuse.org/debug/update/leap/42.1/</url>
+                <url>http://download.opensuse.org/debug/update/leap/42.1/oss/</url>
             </repository>
             <repository recommended="false" format="rpm-md">
                 <_name>Untested Updates</_name>


### PR DESCRIPTION
Fixes [boo#961364](https://bugzilla.opensuse.org/show_bug.cgi?id=961364).