### PR TITLE
Add a link to the Tumbleweed_Community_Additional repositories xml file

### DIFF
--- a/YaST/Repos/openSUSE_Factory_Servers.xml
+++ b/YaST/Repos/openSUSE_Factory_Servers.xml
@@ -11,8 +11,10 @@
 	</item>
 
 
-
-	
+	<item>
+	    <link>http://opensuse-community.org/openSUSE_Tumbleweed_Community_Additional.xml</link>
+	    <official config:type="boolean">false</official>
+        </item>
 
     </servers>
 </productDefines>

--- a/YaST/Repos/openSUSE_Factory_Servers.xml.in
+++ b/YaST/Repos/openSUSE_Factory_Servers.xml.in
@@ -12,6 +12,12 @@
 	    <official config:type="boolean">true</official>
 	</item>
 
+
+	<item>
+	    <link>http://opensuse-community.org/openSUSE_Tumbleweed_Community_Additional.xml</link>
+	    <official config:type="boolean">false</official>
+        </item>
+
 <!-- No OBS repos for factory recommended
 	<item>
 	    <link>http://download.opensuse.org/YaST/Repos/_openSUSE_Factory_Additional.xml</link>
@@ -19,7 +25,7 @@
 	</item>
 -->
 
-	<!-- Community links 
+	<!-- Community links
 	<item>
 	    <link>http://opensuse-community.org/openSUSE_Factory_Community_Additional.xml</link>
 	    <official config:type="boolean">false</official>


### PR DESCRIPTION
This should fix yast to show packman and the libdvdcss repository in the community
repositories list, instead of an empty list.