### PR TITLE
Fetch link references via HTTPS

### DIFF
--- a/YaST/Repos/openSUSE_Factory_Servers.xml
+++ b/YaST/Repos/openSUSE_Factory_Servers.xml
@@ -4,7 +4,7 @@
 
 	
 	<item>
-	    <link>http://download.opensuse.org/YaST/Repos/_openSUSE_Factory_Default.xml</link>
+	    <link>https://download.opensuse.org/YaST/Repos/_openSUSE_Factory_Default.xml</link>
 	    
 	    <installation_repo config:type="boolean">true</installation_repo>
 	    <official config:type="boolean">true</official>

--- a/YaST/Repos/openSUSE_Factory_Servers.xml.in
+++ b/YaST/Repos/openSUSE_Factory_Servers.xml.in
@@ -6,7 +6,7 @@
 
 	<!-- official openSUSE links -->
 	<item>
-	    <link>http://download.opensuse.org/YaST/Repos/_openSUSE_Factory_Default.xml</link>
+	    <link>https://download.opensuse.org/YaST/Repos/_openSUSE_Factory_Default.xml</link>
 	    <!-- to enable it during installation -->
 	    <installation_repo config:type="boolean">true</installation_repo>
 	    <official config:type="boolean">true</official>
@@ -20,7 +20,7 @@
 
 <!-- No OBS repos for factory recommended
 	<item>
-	    <link>http://download.opensuse.org/YaST/Repos/_openSUSE_Factory_Additional.xml</link>
+	    <link>https://download.opensuse.org/YaST/Repos/_openSUSE_Factory_Additional.xml</link>
 	    <official config:type="boolean">true</official>
 	</item>
 -->

--- a/YaST/Repos/openSUSE_aarch64_Factory_Servers.xml
+++ b/YaST/Repos/openSUSE_aarch64_Factory_Servers.xml
@@ -4,7 +4,7 @@
 
 	
 	<item>
-	    <link>http://download.opensuse.org/YaST/Repos/_openSUSE_aarch64_Factory_Default.xml</link>
+	    <link>https://download.opensuse.org/YaST/Repos/_openSUSE_aarch64_Factory_Default.xml</link>
 	    
 	    <installation_repo config:type="boolean">true</installation_repo>
 	    <official config:type="boolean">true</official>

--- a/YaST/Repos/openSUSE_aarch64_Factory_Servers.xml.in
+++ b/YaST/Repos/openSUSE_aarch64_Factory_Servers.xml.in
@@ -6,7 +6,7 @@
 
 	<!-- official openSUSE links -->
 	<item>
-	    <link>http://download.opensuse.org/YaST/Repos/_openSUSE_aarch64_Factory_Default.xml</link>
+	    <link>https://download.opensuse.org/YaST/Repos/_openSUSE_aarch64_Factory_Default.xml</link>
 	    <!-- to enable it during installation -->
 	    <installation_repo config:type="boolean">true</installation_repo>
 	    <official config:type="boolean">true</official>
@@ -20,7 +20,7 @@
 
 <!-- No OBS repos for factory recommended
 	<item>
-	    <link>http://download.opensuse.org/YaST/Repos/_openSUSE_Factory_Additional.xml</link>
+	    <link>https://download.opensuse.org/YaST/Repos/_openSUSE_Factory_Additional.xml</link>
 	    <official config:type="boolean">true</official>
 	</item>
 -->

--- a/YaST/Repos/openSUSE_armv6hl_Factory_Servers.xml
+++ b/YaST/Repos/openSUSE_armv6hl_Factory_Servers.xml
@@ -4,7 +4,7 @@
 
 	
 	<item>
-	    <link>http://download.opensuse.org/YaST/Repos/_openSUSE_armv6hl_Factory_Default.xml</link>
+	    <link>https://download.opensuse.org/YaST/Repos/_openSUSE_armv6hl_Factory_Default.xml</link>
 	    
 	    <installation_repo config:type="boolean">true</installation_repo>
 	    <official config:type="boolean">true</official>

--- a/YaST/Repos/openSUSE_armv6hl_Factory_Servers.xml.in
+++ b/YaST/Repos/openSUSE_armv6hl_Factory_Servers.xml.in
@@ -6,7 +6,7 @@
 
 	<!-- official openSUSE links -->
 	<item>
-	    <link>http://download.opensuse.org/YaST/Repos/_openSUSE_armv6hl_Factory_Default.xml</link>
+	    <link>https://download.opensuse.org/YaST/Repos/_openSUSE_armv6hl_Factory_Default.xml</link>
 	    <!-- to enable it during installation -->
 	    <installation_repo config:type="boolean">true</installation_repo>
 	    <official config:type="boolean">true</official>
@@ -20,7 +20,7 @@
 
 <!-- No OBS repos for factory recommended
 	<item>
-	    <link>http://download.opensuse.org/YaST/Repos/_openSUSE_Factory_Additional.xml</link>
+	    <link>https://download.opensuse.org/YaST/Repos/_openSUSE_Factory_Additional.xml</link>
 	    <official config:type="boolean">true</official>
 	</item>
 -->

--- a/YaST/Repos/openSUSE_armv7hl_Factory_Servers.xml
+++ b/YaST/Repos/openSUSE_armv7hl_Factory_Servers.xml
@@ -4,7 +4,7 @@
 
 	
 	<item>
-	    <link>http://download.opensuse.org/YaST/Repos/_openSUSE_armv7hl_Factory_Default.xml</link>
+	    <link>https://download.opensuse.org/YaST/Repos/_openSUSE_armv7hl_Factory_Default.xml</link>
 	    
 	    <installation_repo config:type="boolean">true</installation_repo>
 	    <official config:type="boolean">true</official>

--- a/YaST/Repos/openSUSE_armv7hl_Factory_Servers.xml.in
+++ b/YaST/Repos/openSUSE_armv7hl_Factory_Servers.xml.in
@@ -6,7 +6,7 @@
 
 	<!-- official openSUSE links -->
 	<item>
-	    <link>http://download.opensuse.org/YaST/Repos/_openSUSE_armv7hl_Factory_Default.xml</link>
+	    <link>https://download.opensuse.org/YaST/Repos/_openSUSE_armv7hl_Factory_Default.xml</link>
 	    <!-- to enable it during installation -->
 	    <installation_repo config:type="boolean">true</installation_repo>
 	    <official config:type="boolean">true</official>
@@ -20,7 +20,7 @@
 
 <!-- No OBS repos for factory recommended
 	<item>
-	    <link>http://download.opensuse.org/YaST/Repos/_openSUSE_Factory_Additional.xml</link>
+	    <link>https://download.opensuse.org/YaST/Repos/_openSUSE_Factory_Additional.xml</link>
 	    <official config:type="boolean">true</official>
 	</item>
 -->

--- a/YaST/Repos/openSUSE_ppc_Factory_Servers.xml
+++ b/YaST/Repos/openSUSE_ppc_Factory_Servers.xml
@@ -4,7 +4,7 @@
 
 	
 	<item>
-	    <link>http://download.opensuse.org/YaST/Repos/_openSUSE_ppc_Factory_Default.xml</link>
+	    <link>https://download.opensuse.org/YaST/Repos/_openSUSE_ppc_Factory_Default.xml</link>
 	    
 	    <installation_repo config:type="boolean">true</installation_repo>
 	    <official config:type="boolean">true</official>

--- a/YaST/Repos/openSUSE_ppc_Factory_Servers.xml.in
+++ b/YaST/Repos/openSUSE_ppc_Factory_Servers.xml.in
@@ -6,7 +6,7 @@
 
 	<!-- official openSUSE links -->
 	<item>
-	    <link>http://download.opensuse.org/YaST/Repos/_openSUSE_ppc_Factory_Default.xml</link>
+	    <link>https://download.opensuse.org/YaST/Repos/_openSUSE_ppc_Factory_Default.xml</link>
 	    <!-- to enable it during installation -->
 	    <installation_repo config:type="boolean">true</installation_repo>
 	    <official config:type="boolean">true</official>
@@ -20,7 +20,7 @@
 
 <!-- No OBS repos for factory recommended
 	<item>
-	    <link>http://download.opensuse.org/YaST/Repos/_openSUSE_Factory_Additional.xml</link>
+	    <link>https://download.opensuse.org/YaST/Repos/_openSUSE_Factory_Additional.xml</link>
 	    <official config:type="boolean">true</official>
 	</item>
 -->


### PR DESCRIPTION
Prevent install-time manipulation of the default distribution repository list by a MITM, who may at a later time present outdated copies with valid signatures to withhold security updates for known vulnerabilities without needing to be MITM at that time.

Change for Leap 15.2 and Tumbleweed only, as these are in active use.