### PR TITLE
Fix empty community repos in Tumbleweed

### DIFF
--- a/YaST/Repos/openSUSE_Factory_Servers.xml
+++ b/YaST/Repos/openSUSE_Factory_Servers.xml
@@ -12,7 +12,7 @@
 
 
 	<item>
-	    <link>https://opensuse-community.org/openSUSE_Tumbleweed_Community_Additional.xml</link>
+	    <link>https://www.opensuse-community.org/openSUSE_Tumbleweed_Community_Additional.xml</link>
 	    <official config:type="boolean">false</official>
         </item>
 

--- a/YaST/Repos/openSUSE_Factory_Servers.xml.in
+++ b/YaST/Repos/openSUSE_Factory_Servers.xml.in
@@ -14,7 +14,7 @@
 
 
 	<item>
-	    <link>https://opensuse-community.org/openSUSE_Tumbleweed_Community_Additional.xml</link>
+	    <link>https://www.opensuse-community.org/openSUSE_Tumbleweed_Community_Additional.xml</link>
 	    <official config:type="boolean">false</official>
         </item>
 

--- a/YaST/Repos/openSUSE_aarch64_Factory_Servers.xml
+++ b/YaST/Repos/openSUSE_aarch64_Factory_Servers.xml
@@ -12,7 +12,7 @@
 
 
 	<item>
-	    <link>https://opensuse-community.org/openSUSE_aarch64_Tumbleweed_Community_Additional.xml</link>
+	    <link>https://www.opensuse-community.org/openSUSE_aarch64_Tumbleweed_Community_Additional.xml</link>
 	    <official config:type="boolean">false</official>
         </item>
 

--- a/YaST/Repos/openSUSE_aarch64_Factory_Servers.xml.in
+++ b/YaST/Repos/openSUSE_aarch64_Factory_Servers.xml.in
@@ -14,7 +14,7 @@
 
 
 	<item>
-	    <link>https://opensuse-community.org/openSUSE_aarch64_Tumbleweed_Community_Additional.xml</link>
+	    <link>https://www.opensuse-community.org/openSUSE_aarch64_Tumbleweed_Community_Additional.xml</link>
 	    <official config:type="boolean">false</official>
         </item>
 

--- a/YaST/Repos/openSUSE_armv6hl_Factory_Servers.xml
+++ b/YaST/Repos/openSUSE_armv6hl_Factory_Servers.xml
@@ -12,7 +12,7 @@
 
 
 	<item>
-	    <link>https://opensuse-community.org/openSUSE_armv6hl_Tumbleweed_Community_Additional.xml</link>
+	    <link>https://www.opensuse-community.org/openSUSE_armv6hl_Tumbleweed_Community_Additional.xml</link>
 	    <official config:type="boolean">false</official>
         </item>
 

--- a/YaST/Repos/openSUSE_armv6hl_Factory_Servers.xml.in
+++ b/YaST/Repos/openSUSE_armv6hl_Factory_Servers.xml.in
@@ -14,7 +14,7 @@
 
 
 	<item>
-	    <link>https://opensuse-community.org/openSUSE_armv6hl_Tumbleweed_Community_Additional.xml</link>
+	    <link>https://www.opensuse-community.org/openSUSE_armv6hl_Tumbleweed_Community_Additional.xml</link>
 	    <official config:type="boolean">false</official>
         </item>
 

--- a/YaST/Repos/openSUSE_armv7hl_Factory_Servers.xml
+++ b/YaST/Repos/openSUSE_armv7hl_Factory_Servers.xml
@@ -12,7 +12,7 @@
 
 
 	<item>
-	    <link>https://opensuse-community.org/openSUSE_armv7hl_Tumbleweed_Community_Additional.xml</link>
+	    <link>https://www.opensuse-community.org/openSUSE_armv7hl_Tumbleweed_Community_Additional.xml</link>
 	    <official config:type="boolean">false</official>
         </item>
 

--- a/YaST/Repos/openSUSE_armv7hl_Factory_Servers.xml.in
+++ b/YaST/Repos/openSUSE_armv7hl_Factory_Servers.xml.in
@@ -14,7 +14,7 @@
 
 
 	<item>
-	    <link>https://opensuse-community.org/openSUSE_armv7hl_Tumbleweed_Community_Additional.xml</link>
+	    <link>https://www.opensuse-community.org/openSUSE_armv7hl_Tumbleweed_Community_Additional.xml</link>
 	    <official config:type="boolean">false</official>
         </item>
 

--- a/YaST/Repos/openSUSE_ppc_Factory_Servers.xml
+++ b/YaST/Repos/openSUSE_ppc_Factory_Servers.xml
@@ -12,7 +12,7 @@
 
 
 	<item>
-	    <link>https://opensuse-community.org/openSUSE_ppc_Tumbleweed_Community_Additional.xml</link>
+	    <link>https://www.opensuse-community.org/openSUSE_ppc_Tumbleweed_Community_Additional.xml</link>
 	    <official config:type="boolean">false</official>
         </item>
 

--- a/YaST/Repos/openSUSE_ppc_Factory_Servers.xml.in
+++ b/YaST/Repos/openSUSE_ppc_Factory_Servers.xml.in
@@ -14,7 +14,7 @@
 
 
 	<item>
-	    <link>https://opensuse-community.org/openSUSE_ppc_Tumbleweed_Community_Additional.xml</link>
+	    <link>https://www.opensuse-community.org/openSUSE_ppc_Tumbleweed_Community_Additional.xml</link>
 	    <official config:type="boolean">false</official>
         </item>
 


### PR DESCRIPTION
These changes are the same as [this](https://github.com/openSUSE/download.o.o/pull/39#issue-1369770806), but for TW.